### PR TITLE
API can provide products sorted in categories

### DIFF
--- a/app/controllers/api/menu_items_controller.rb
+++ b/app/controllers/api/menu_items_controller.rb
@@ -3,4 +3,5 @@ class Api::MenuItemsController < ApplicationController
     menu_items = MenuItem.all
     render json: { menu_items: menu_items }
   end
+  
 end

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -25,7 +25,7 @@ class Api::OrdersController < ApplicationController
            }  
         },status: status
       else
-        render json: { message: "Something went wrong! "}, status: 422
+        render json: { message: "Unauthorised action"}, status: 401
       end
   end
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,4 +1,4 @@
 class MenuItem < ApplicationRecord
-  validates_presence_of :title, :price
+  validates_presence_of :title, :price, :category
   has_many :order_items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
-      resources :menu_items, only: [:index]
-      resources :orders, only: [:create, :update]
-    end
+    resources :menu_items, only: [:index]
+    resources :orders, only: %i[create update]
   end
+end

--- a/db/migrate/20210501165116_add_category_to_menu_items.rb
+++ b/db/migrate/20210501165116_add_category_to_menu_items.rb
@@ -1,0 +1,5 @@
+class AddCategoryToMenuItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :menu_items, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_30_171358) do
+ActiveRecord::Schema.define(version: 2021_05_01_165116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2021_04_30_171358) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "description"
     t.integer "price"
+    t.string "category"
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/spec/factories/menu_item.rb
+++ b/spec/factories/menu_item.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
     title { "Tikka Masala" }
     description { "Chicken, Rice, sauce" }
     price { 70 }
+    category { "mains" }
+    
   end
 end

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -3,11 +3,13 @@ RSpec.describe MenuItem, type: :model do
     it { is_expected.to have_db_column(:title).of_type(:string) }
     it { is_expected.to have_db_column(:description).of_type(:string) }
     it { is_expected.to have_db_column(:price).of_type(:integer) }
+    it { is_expected.to have_db_column(:category).of_type(:string)}
   end
 
   describe 'Validation of title' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :price }
+    it { is_expected.to validate_presence_of :category}
   end
 
   describe 'factory' do

--- a/spec/requests/api/api_provides_collection_of_menu_items_by_category_spec.rb
+++ b/spec/requests/api/api_provides_collection_of_menu_items_by_category_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'GET api/menu_items/', type: :request do
+  let!(:menu_item_1) { create(:menu_item, title: 'kebab', description: 'rice with kebab', price: 100, category: 'mains') }
+
+  describe 'successfully' do
+    before do
+      get '/api/menu_items'
+    end
+
+    it 'is expected to respond with status 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to a category of mains' do
+      expect(response_json['menu_items'].first['category']).to eq 'mains'
+    end
+    
+  end
+end

--- a/spec/requests/api/api_provides_user_to_update_existing_order_spec.rb
+++ b/spec/requests/api/api_provides_user_to_update_existing_order_spec.rb
@@ -1,26 +1,43 @@
 RSpec.describe 'PUT /api/orders/:id' do
-  let(:user) {create(:user)}
-  let(:auth_headers) {user.create_new_auth_token}
-  let(:order) {create(:order, user_id: user.id)}
-  let(:ordered_menu_item) {create(:menu_item)}
-  let(:menu_item_to_order) {create(:menu_item, title: "Tikka Masala")}
+  let(:user) { create(:user) }
+  let(:auth_headers) { user.create_new_auth_token }
+  let(:order) { create(:order, user_id: user.id) }
+  let(:ordered_menu_item) { create(:menu_item) }
+  let(:menu_item_to_order) { create(:menu_item, title: 'Tikka Masala') }
   describe 'successfully with valid  params' do
     before do
       order.order_items.create(menu_item_id: ordered_menu_item.id)
       put "/api/orders/#{order.id}",
-      params: {menu_item_id: menu_item_to_order.id},
-      headers: auth_headers
+          params: { menu_item_id: menu_item_to_order.id },
+          headers: auth_headers
     end
-  it 'is expected to return a 200 status' do
-    expect(response).to have_http_status 200
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to add menu items' do
+      expect(response_json['order']['items'].count).to eq 2
+    end
+
+    it 'is expected to be a Tikka Massala in the order' do
+      expect(response_json['order']['items'].second['title']).to eq 'Tikka Masala'
+    end
   end
 
-  it 'is expected to add menu items' do
-    expect(response_json['order']['items'].count).to eq 2
-  end
+  describe 'unsuccessfully' do
+    before do
+      order.order_items.create(menu_item_id: ordered_menu_item.id)
+      put "/api/orders/#{order.id}",
+          params: { menu_item_id: menu_item_to_order.id },
+          headers: {}
+    end
 
-  it 'is expected to be a Tikka Massala in the order' do
-    expect(response_json['order']['items'].second['title']).to eq "Tikka Masala"
-  end
+    it 'is expected to return a status of 401' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'is expected to return a message of Unauthorised action' do
+      expect((response_json)['errors'].first).to eq 'You need to sign in or sign up before continuing.'
+    end
   end
 end


### PR DESCRIPTION
Pt : https://www.pivotaltracker.com/story/show/177903759
## User story 
```
As a restaurant API
In order to give the client better sorted products
I would like to be able to send off the products with their category listed
```
## suggested changes 
-  adds category to menu items table
